### PR TITLE
Fix when update-changes chooses to amend commits

### DIFF
--- a/devel-tools/update-changes
+++ b/devel-tools/update-changes
@@ -440,7 +440,7 @@ cat $file_changes >>$tmp
 # commit even if the user wants otherwise.
 amend=0
 if git remote | grep -q origin; then
-     if git rev-list origin..HEAD | grep -q .; then
+     if git rev-list origin/`git rev-parse --abbrev-ref HEAD`..HEAD | grep -q .; then
          amend=1
      fi
 fi


### PR DESCRIPTION
The old logic didn't work when used on a branch (e.g. release/X.Y for
doing releases) because "origin..HEAD" assumes to compare origin/master
versus HEAD and so thinks there's un-pushed commits in the local branch
that are safe to amend.