### PR TITLE
Add a script for running benchmarks on linux vs recorded data sets

### DIFF
--- a/devel-tools/perf-benchmark
+++ b/devel-tools/perf-benchmark
@@ -1,0 +1,136 @@
+#!/bin/sh
+
+ZEEK_BUILD=""
+DATA_FILE=""
+MODE="benchmark"
+
+# Path where flamegraph is installed
+FLAMEGRAPH_PATH=/usr/local/FlameGraph
+
+usage() {
+    usage="\
+Usage: $0 -b [zeek binary path] -d [data file path]
+
+  Options:
+    -b path        The path to a Zeek binary to benchmark
+    -d path        The path to a data file to read from for replay
+    -f path        (optional) The path to an SVG file to output a flamegraph
+                   for the benchmark run
+
+    By defualt the output will include CPU, memory, etc statistics from Zeek
+    processing all of the data in the data file. With the -f argument, the
+    script will instead output a flamegraph for the process runtime, showing
+    the time spent in functions, etc.
+"
+
+    echo "${usage}"
+    exit 1
+}
+
+while (( "$#" )); do
+  case "$1" in
+      -d|--data-file)
+	  DATA_FILE=$2
+	  shift 2
+	  ;;
+      -b|--build)
+	  ZEEK_BUILD=$2
+	  shift 2
+	  ;;
+      -f|--flame-graph)
+	  MODE="flamegraph"
+	  FG_FILE=$2
+	  shift 2
+	  ;;
+  esac
+done
+
+if [ -z $ZEEK_BUILD ]; then
+    echo "Error: -b argument is required and should point at a Zeek binary"
+    echo
+    usage
+fi
+
+if [ -z $DATA_FILE ]; then
+    echo "Error: -d argument is required and should point at a pcap file to replay"
+    echo
+    usage
+fi
+
+# Various run-time options
+INTERFACE="ens1f0"
+ZEEK_ARGS="-i af_packet::${INTERFACE}"
+ZEEK_CPU=10
+TCPREPLAY_CPU=11
+
+echo "Running '${ZEEK_BUILD} ${ZEEK_ARGS}' against ${DATA_FILE}"
+
+if [ "${MODE}" = "benchmark" ]; then
+
+    TIME_FILE=$(mktemp)
+
+    # Start zeek, find it's PID, then wait 10s to let it reach a steady state
+    taskset --cpu-list $ZEEK_CPU time -f "%M" -o ${TIME_FILE} $ZEEK_BUILD $ZEEK_ARGS &
+    TIME_PID=$!
+
+    sleep 10
+
+    ZEEK_PID=$(ps -ef | awk -v timepid="${TIME_PID}" '{ if ($3 == timepid) { print $2 } }')
+    echo "Zeek running on PID ${ZEEK_PID}"
+
+    # Start perf stat on the zeek process
+    perf stat -p ${ZEEK_PID} &
+    PERF_PID=$!
+
+    # Start replaying the data
+    echo "Starting replay"
+    taskset --cpu-list $TCPREPLAY_CPU tcpreplay -i $INTERFACE -q $DATA_FILE
+
+    # TODO: does it make sense to sleep here to let zeek finish processing all of the packets
+    # out of the kernel buffer?
+
+    # Print the average CPU usage of the process
+    echo
+    CPU_USAGE=$(ps -p $ZEEK_PID -o %cpu=)
+
+    # Kill everything
+    kill -2 $ZEEK_PID
+    wait $TIME_PID
+    wait $PERF_PID
+
+    echo "Maximum memory usage (max_rss): $(head -n 1 ${TIME_FILE}) bytes"
+    echo "Average CPU usage: ${CPU_USAGE}%"
+
+    rm $TIME_FILE
+
+elif [ "${MODE}" = "flamegraph" ]; then
+
+    PERF_RECORD_FILE=$(mktemp)
+
+    # Start zeek under perf record, then sleep for a few seconds to let it actually start up. For runs with
+    # shorter amounts of data or with slower traffic, you can add '-c 499' here to get finer-grained results.
+    # With big data sets, it just results in the graph getting blown out by waits in the IO loop.
+    perf record -g -o $PERF_RECORD_FILE -- $ZEEK_BUILD $ZEEK_ARGS &
+    PERF_PID=$!
+
+    sleep 5
+
+    ZEEK_PID=$(ps -ef | awk -v perfpid="${PERF_PID}" '{ if ($3 == perfpid) { print $2 } }')
+    echo "Zeek running on PID ${ZEEK_PID}"
+    echo
+
+    # Start replaying the data
+    echo "Starting replay"
+    taskset --cpu-list $TCPREPLAY_CPU tcpreplay -i $INTERFACE -q $DATA_FILE
+
+    # Kill everything
+    echo
+    kill -2 $ZEEK_PID
+    wait $PERF_PID
+
+    echo
+    echo "Building SVG for output"
+    perf script -i $PERF_RECORD_FILE | ${FLAMEGRAPH_PATH}/stackcollapse-perf.pl | ${FLAMEGRAPH_PATH}/flamegraph.pl > ${FG_FILE}
+    rm $PERF_RECORD_FILE
+
+fi

--- a/devel-tools/perf-benchmark
+++ b/devel-tools/perf-benchmark
@@ -3,24 +3,36 @@
 ZEEK_BUILD=""
 DATA_FILE=""
 MODE="benchmark"
+INTERFACE=""
 
 # Path where flamegraph is installed
-FLAMEGRAPH_PATH=/usr/local/FlameGraph
+FLAMEGRAPH_PATH=""
+FLAMEGRAPH_OUTPUT=""
 
 usage() {
     usage="\
-Usage: $0 -b [zeek binary path] -d [data file path]
+Usage: $0 -z [zeek binary path] -d [data file path]
 
   Options:
-    -b path        The path to a Zeek binary to benchmark
-    -d path        The path to a data file to read from for replay
-    -f path        (optional) The path to an SVG file to output a flamegraph
-                   for the benchmark run
+    -b, --build PATH        The path to a Zeek binary to benchmark
+    -d, --data-file PATH    The path to a data file to read from for replay
+    -i, --interface INTF    The network interface to use for capturing data.
+                            This interface should be completely idle, since
+                            tcpreplay will be using it to replay the data.
+    -f, --flamegraph PATH   (optional) The path to the directory where
+                            Flamegraph is installed.
+    -o, --output FILE       The file to use as output for Flamegraph. This
+                            will default to 'perf.svg', and is ignored if
+                            the '-f' argument is not passed.
 
-    By defualt the output will include CPU, memory, etc statistics from Zeek
+    By default the output will include CPU, memory, etc statistics from Zeek
     processing all of the data in the data file. With the -f argument, the
     script will instead output a flamegraph for the process runtime, showing
     the time spent in functions, etc.
+
+    This script assumes that it is being run on a system with a large number
+    of CPU cores. If being used on a smaller system, modify this script and
+    set the ZEEK_CPU and TCPREPLAY_CPU variables to smaller values.
 "
 
     echo "${usage}"
@@ -37,9 +49,20 @@ while (( "$#" )); do
 	  ZEEK_BUILD=$2
 	  shift 2
 	  ;;
-      -f|--flame-graph)
+      -i|--interface)
+	  INTERFACE=$2
+	  shift 2
+	  ;;
+      -f|--flamegraph)
 	  MODE="flamegraph"
-	  FG_FILE=$2
+	  FLAMEGRAPH_PATH=$2
+	  if [ -z $FLAMEGRAPH_OUTPUT ]; then
+	      FLAMEGRAPH_OUTPUT="benchmark.svg"
+	  fi
+	  shift 2
+	  ;;
+      -o|--output)
+	  FLAMEGRAPH_OUTPUT=$2
 	  shift 2
 	  ;;
   esac
@@ -57,8 +80,13 @@ if [ -z $DATA_FILE ]; then
     usage
 fi
 
+if [ -z $INTERFACE ]; then
+    echo "Error: -i argument is required and should point to an idle network interface"
+    echo
+    usage
+fi
+
 # Various run-time options
-INTERFACE="ens1f0"
 ZEEK_ARGS="-i af_packet::${INTERFACE}"
 ZEEK_CPU=10
 TCPREPLAY_CPU=11
@@ -70,7 +98,7 @@ if [ "${MODE}" = "benchmark" ]; then
     TIME_FILE=$(mktemp)
 
     # Start zeek, find it's PID, then wait 10s to let it reach a steady state
-    taskset --cpu-list $ZEEK_CPU time -f "%M" -o ${TIME_FILE} $ZEEK_BUILD $ZEEK_ARGS &
+    taskset --cpu-list $ZEEK_CPU time -f "%M" -o $TIME_FILE $ZEEK_BUILD $ZEEK_ARGS &
     TIME_PID=$!
 
     sleep 10
@@ -79,7 +107,7 @@ if [ "${MODE}" = "benchmark" ]; then
     echo "Zeek running on PID ${ZEEK_PID}"
 
     # Start perf stat on the zeek process
-    perf stat -p ${ZEEK_PID} &
+    perf stat -p $ZEEK_PID &
     PERF_PID=$!
 
     # Start replaying the data
@@ -89,11 +117,11 @@ if [ "${MODE}" = "benchmark" ]; then
     # TODO: does it make sense to sleep here to let zeek finish processing all of the packets
     # out of the kernel buffer?
 
-    # Print the average CPU usage of the process
-    echo
+    # Capture the average CPU usage of the process
     CPU_USAGE=$(ps -p $ZEEK_PID -o %cpu=)
 
     # Kill everything
+    echo
     kill -2 $ZEEK_PID
     wait $TIME_PID
     wait $PERF_PID
@@ -117,7 +145,6 @@ elif [ "${MODE}" = "flamegraph" ]; then
 
     ZEEK_PID=$(ps -ef | awk -v perfpid="${PERF_PID}" '{ if ($3 == perfpid) { print $2 } }')
     echo "Zeek running on PID ${ZEEK_PID}"
-    echo
 
     # Start replaying the data
     echo "Starting replay"
@@ -129,8 +156,8 @@ elif [ "${MODE}" = "flamegraph" ]; then
     wait $PERF_PID
 
     echo
-    echo "Building SVG for output"
-    perf script -i $PERF_RECORD_FILE | ${FLAMEGRAPH_PATH}/stackcollapse-perf.pl | ${FLAMEGRAPH_PATH}/flamegraph.pl > ${FG_FILE}
+    echo "Building flamegraph, writing to ${FLAMEGRAPH_OUTPUT}"
+    perf script -i $PERF_RECORD_FILE | ${FLAMEGRAPH_PATH}/stackcollapse-perf.pl | ${FLAMEGRAPH_PATH}/flamegraph.pl > $FLAMEGRAPH_OUTPUT
     rm $PERF_RECORD_FILE
 
 fi


### PR DESCRIPTION
This adds a script for running benchmarks on Linux systems. It provides a mode for outputting straight performance (CPU, memory usage, etc) data and one for outputting flamegraphs.

There's an issue right now where it won't output exactly the same numbers from one run to another, but that might just be variance on the system during run time. The numbers are very close to each other, normally within a half percent of overall CPU usage for 600Mbps of data.