### PR TITLE
Updates to the benchmarking script

### DIFF
--- a/devel-tools/perf-benchmark
+++ b/devel-tools/perf-benchmark
@@ -2,12 +2,13 @@
 
 ZEEK_BUILD=""
 DATA_FILE=""
-MODE="benchmark"
+MODE="intf"
 INTERFACE=""
+SEED_FILE=""
 
 # Path where flamegraph is installed
 FLAMEGRAPH_PATH=""
-FLAMEGRAPH_OUTPUT=""
+FLAMEGRAPH_PREFIX="benchmark"
 
 usage() {
     usage="\
@@ -16,28 +17,50 @@ Usage: $0 -z [zeek binary path] -d [data file path]
   Options:
     -b, --build PATH        The path to a Zeek binary to benchmark
     -d, --data-file PATH    The path to a data file to read from for replay
+    -m, --mode MODE         This can be one of three possible values:
+                            intf, read, or flamegraph. This controls what
+                            mode is used for the benchmark run, and defaults
+                            to intf if not passed. The modes are described
+                            below.
     -i, --interface INTF    The network interface to use for capturing data.
                             This interface should be completely idle, since
                             tcpreplay will be using it to replay the data.
-    -f, --flamegraph PATH   (optional) The path to the directory where
-                            Flamegraph is installed.
-    -o, --output FILE       The file to use as output for Flamegraph. This
-                            will default to 'benchmark.svg', and is ignored
-                            if the '-f' argument is not passed.
+                            This argument is ignored if the mode is 'file'.
+    -f, --flamegraph PATH   The path to the directory where Flamegraph is
+                            installed. This argument is required if the mode
+                            is 'flamegraph', but is ignored otherwise.
+    -o, --output FILE       The file prefix to use as output for Flamegraph.
+                            This defaults to 'benchmark'. This argument is ignored
+                            if the mode is not 'flamegraph'.
+    -s, --seed FILE         (optional) A path to a Zeek random seed file.
+                            This is used control the generation of connection
+                            IDs and other data so it is consistent between
+                            benchmarking runs.
 
-    By default the output will include CPU, memory, etc statistics from Zeek
-    processing all of the data in the data file. With the -f argument, the
-    script will instead output a flamegraph for the process runtime, showing
-    the time spent in functions, etc.
+    By default or when 'intf' is passed for the mode argument, the output will
+    include CPU, memory, etc statistics from Zeek processing all of the data
+    in the data file as if it was reading it live from the network. This mode
+    requires an interface to be passed using the -i argument.
 
-    This script assumes that it is being run on a system with a large number
-    of CPU cores. If being used on a smaller system, modify this script and
-    set the ZEEK_CPU and TCPREPLAY_CPU variables to smaller values.
+    When 'file' is passed for the mode (-m) argument, the output will include
+    the runtime and maximum memory usage of Zeek when reading the data file
+    directly from disk.
+
+    When 'flamegraph' is passed for the mode (-m) argument, this script will
+    output two flamegraphs for the process runtime in svg format. The first
+    flamegraph is a standard graph showing the time spent in functions,
+    stacked in the normal manner. The second graph is 'stack-reversed'.
 
     Symbols in Flamegraph outputs may not correctly stack unless the various
     libraries linked into Zeek are built with frame pointers. This includes
     glibc, libpcap, and openssl. Rebuilding those libraries with the
     -fno-omit-frame-pointer compiler flag may provide more accurate output.
+    You can set libraries that get preloaded by setting the PRELOAD_LIBS
+    varaible in the script.
+
+    This script assumes that it is being run on a system with a large number
+    of CPU cores. If being used on a smaller system, modify this script and
+    set the ZEEK_CPU and TCPREPLAY_CPU variables to smaller values.
 "
 
     echo "${usage}"
@@ -54,54 +77,73 @@ while (( "$#" )); do
 	  ZEEK_BUILD=$2
 	  shift 2
 	  ;;
+      -m|--mode)
+	  MODE=$2
+	  shift 2
+	  ;;
       -i|--interface)
 	  INTERFACE=$2
 	  shift 2
 	  ;;
       -f|--flamegraph)
-	  MODE="flamegraph"
 	  FLAMEGRAPH_PATH=$2
-	  if [ -z $FLAMEGRAPH_OUTPUT ]; then
-	      FLAMEGRAPH_OUTPUT="benchmark.svg"
-	  fi
 	  shift 2
 	  ;;
       -o|--output)
-	  FLAMEGRAPH_OUTPUT=$2
+	  FLAMEGRAPH_PREFIX=$2
+	  shift 2
+	  ;;
+      -s|--seed)
+	  SEED_FILE=$2
 	  shift 2
 	  ;;
   esac
 done
 
-if [ -z $ZEEK_BUILD ]; then
+if [ "${MODE}" != "intf" -a "${MODE}" != "file" -a "${MODE}" != "flamegraph" ]; then
+    echo "Error: -m argument should be one of 'intf', 'file', or 'flamegraph'"
+    echo
+    usage
+fi
+
+if [ -z "${ZEEK_BUILD}" ]; then
     echo "Error: -b argument is required and should point at a Zeek binary"
     echo
     usage
 fi
 
-if [ -z $DATA_FILE ]; then
+if [ -z "${DATA_FILE}" ]; then
     echo "Error: -d argument is required and should point at a pcap file to replay"
     echo
     usage
 fi
 
-if [ -z $INTERFACE ]; then
-    echo "Error: -i argument is required and should point to an idle network interface"
+if [ "${MODE}" != "file" -a -z "${INTERFACE}" ]; then
+    echo "Error: -i argument is required for the ${MODE} mode and should point to an idle network interface"
     echo
     usage
 fi
 
 # Various run-time options
-ZEEK_ARGS="-i af_packet::${INTERFACE}"
 ZEEK_CPU=10
 TCPREPLAY_CPU=11
+PRELOAD_LIBS=""
 
-echo "Running '${ZEEK_BUILD} ${ZEEK_ARGS}' against ${DATA_FILE}"
+ZEEK_ARGS=""
+if [ "${MODE}" != "file" ]; then
+    ZEEK_ARGS="-i af_packet::${INTERFACE}"
+fi
 
-if [ "${MODE}" = "benchmark" ]; then
+if [ -n "${SEED_FILE}" ]; then
+    ZEEK_ARGS="${ZEEK_ARGS} -G ${SEED_FILE}"
+fi
+
+if [ "${MODE}" = "intf" ]; then
 
     TIME_FILE=$(mktemp)
 
+    echo "####### Testing reading data file from a network interface #######"
+    echo "Running '${ZEEK_BUILD} ${ZEEK_ARGS}' against ${DATA_FILE}"
     # Start zeek, find it's PID, then wait 10s to let it reach a steady state
     taskset --cpu-list $ZEEK_CPU time -f "%M" -o $TIME_FILE $ZEEK_BUILD $ZEEK_ARGS &
     TIME_PID=$!
@@ -119,9 +161,6 @@ if [ "${MODE}" = "benchmark" ]; then
     echo "Starting replay"
     taskset --cpu-list $TCPREPLAY_CPU tcpreplay -i $INTERFACE -q $DATA_FILE
 
-    # TODO: does it make sense to sleep here to let zeek finish processing all of the packets
-    # out of the kernel buffer?
-
     # Capture the average CPU usage of the process
     CPU_USAGE=$(ps -p $ZEEK_PID -o %cpu=)
 
@@ -136,14 +175,27 @@ if [ "${MODE}" = "benchmark" ]; then
 
     rm $TIME_FILE
 
+elif [ "${MODE}" = "file" ]; then
+
+    TIME_FILE=$(mktemp)
+
+    echo "####### Testing reading the file directly from disk #######"
+    taskset --cpu-list $ZEEK_CPU time -f "%e %M" -o $TIME_FILE $ZEEK_BUILD $ZEEK_ARGS -r $DATA_FILE
+    awk '{print "Time spent: " $1 " seconds\nMax memory usage: " $2 " bytes"}' $TIME_FILE
+
+    rm $TIME_FILE
+
 elif [ "${MODE}" = "flamegraph" ]; then
 
+    echo "####### Generating flamegraph data #######"
+
     PERF_RECORD_FILE=$(mktemp)
+    PERF_COLLAPSED_FILE=$(mktemp)
 
     # Start zeek under perf record, then sleep for a few seconds to let it actually start up. For runs with
     # shorter amounts of data or with slower traffic, you can add '-c 499' here to get finer-grained results.
     # With big data sets, it just results in the graph getting blown out by waits in the IO loop.
-    perf record -g -o $PERF_RECORD_FILE -- $ZEEK_BUILD $ZEEK_ARGS &
+    LD_PRELOAD=${PRELOAD_LIBS} perf record -g -o $PERF_RECORD_FILE -- $ZEEK_BUILD $ZEEK_ARGS &
     PERF_PID=$!
 
     sleep 5
@@ -161,8 +213,14 @@ elif [ "${MODE}" = "flamegraph" ]; then
     wait $PERF_PID
 
     echo
-    echo "Building flamegraph, writing to ${FLAMEGRAPH_OUTPUT}"
-    perf script -i $PERF_RECORD_FILE | ${FLAMEGRAPH_PATH}/stackcollapse-perf.pl | ${FLAMEGRAPH_PATH}/flamegraph.pl > $FLAMEGRAPH_OUTPUT
+    echo "####### Collapsing perf stack data #######"
+    perf script -i $PERF_RECORD_FILE | ${FLAMEGRAPH_PATH}/stackcollapse-perf.pl > $PERF_COLLAPSED_FILE
+    echo "####### Building normal flamegraph, writing to ${FLAMEGRAPH_PREFIX}.svg #######"
+    cat $PERF_COLLAPSED_FILE | ${FLAMEGRAPH_PATH}/flamegraph.pl > "${FLAMEGRAPH_PREFIX}.svg"
+    echo "####### Building reverse flamegraph, writing to ${FLAMEGRAPH_PREFIX}-reversed.svg #######"
+    cat $PERF_COLLAPSED_FILE | ${FLAMEGRAPH_PATH}/flamegraph.pl --reverse > "${FLAMEGRAPH_PREFIX}-reversed.svg"
+
     rm $PERF_RECORD_FILE
+    rm $PERF_COLLAPSED_FILE
 
 fi


### PR DESCRIPTION
- Added --mode argument for setting the benchmarking mode
- Added "file" mode for reading a file directly from disk with the Zeek '-r' argument
- Added reverse flamegraphs to the output from the flamegraph mode
- Added --seed argument for passing a random seed file to Zeek