### PR TITLE
Make some improvements to update-changes

### DIFF
--- a/devel-tools/update-changes
+++ b/devel-tools/update-changes
@@ -147,13 +147,15 @@ function add_to_changes_entry
    author=""
 
    if [ "$msg" == "" ]; then
-       author_email=`$git_author_email $rev`
-       author=`$git_author $rev`
+       if [ "$show_authors" == "1" ]; then
+	   author_email=`$git_author_email $rev`
+	   author=`$git_author $rev`
 
-       if [[ "$author_email" == *@corelight.com ]]; then
-           author="$author, Corelight"
-       else
-           author="$author"
+	   if [[ "$author_email" == *@corelight.com ]]; then
+               author=" ($author, Corelight)"
+	   else
+               author=" ($author)"
+	   fi
        fi
 
        msg=`$git_msg $rev`
@@ -168,6 +170,11 @@ function add_to_changes_entry
        return 1;
    fi
 
+   if echo $msg | grep -q "^Merge remote-tracking branch"; then
+       # Ignore merge commits.
+       return 1;
+   fi
+
    echo >>$dst
 
    if [ "$zeek_style" == "0" ]; then
@@ -176,8 +183,8 @@ function add_to_changes_entry
            bullet="-"
    fi
 
-   ( echo -n "$msg"; test "$author" != "" && test "$show_authors" == "1" && printf " (%s)" "$author" ) \
-       | awk -v bullet="$bullet" 'NR==1{printf "%s %s\n", bullet, $0; next }{printf "    %s\n", $0}' \
+   echo -n "$msg" \
+       | awk -v bullet="$bullet" -v author="$author" 'NR==1{printf "%s %s%s\n", bullet, $0, author; next }{printf "    %s\n", $0}' \
        | sed 's/[[:blank:]]*$//' >>$dst
 
    return 0;
@@ -364,8 +371,6 @@ trap "rm -f $tmp" EXIT
 rm -f $tmp
 
 found=0
-
-echo >>$tmp
 
 new_version=$auto_version
 version=`version $rev`


### PR DESCRIPTION
- Don't insert blank line at the top of the file that just needs to be deleted when you manually edit it.
- Ignore merge commits
- Put the author attribution at the end of the first line of a commit message instead of at the end of the message.

I didn't make the merge commits one have a command-line argument that controls it but I definitely could if that's desired. The last change is something that Jon had talked to me about doing a long time ago and neither one of us ever got around to it. I finally got annoyed enough by the blank line at the start of the file that I figured I'd just take care of all of it at once.