### PR TITLE
Switch from using the CT logs that are included in Chrome

### DIFF
--- a/devel-tools/gen-ct-list.pl
+++ b/devel-tools/gen-ct-list.pl
@@ -11,7 +11,7 @@ use warnings;
 
 # This is the only kind-of user-configurable line
 
-my $google_log_url = "https://www.gstatic.com/ct/log_list/all_logs_list.json";
+my $google_log_url = "https://www.gstatic.com/ct/log_list/log_list.json";
 
 # And begin with loading everything we need.
 # I was lazy and you probably will have to install a few of these.


### PR DESCRIPTION
In the past we used the list of all logs. Since we are using this for
validation it makes more sense to only use the logs that are allowed by
Chrome.

See
https://github.com/google/certificate-transparency-community-site/blob/master/docs/google/known-logs.md
about more details of the different available log lists.