### PR TITLE
Remove package support from init-plugin

### DIFF
--- a/plugin-support/README
+++ b/plugin-support/README
@@ -1,0 +1,4 @@
+The init-plugin script instantiates a plugin template to provide you with a good
+starting point for your next Zeek plugin. Use this only if you want to develop
+a "pure" Zeek plugin -- if you're looking to start a Zeek package for the zkg
+package manager, then use the "zkg create" command instead.

--- a/plugin-support/skeleton/configure
+++ b/plugin-support/skeleton/configure
@@ -176,6 +176,10 @@ if [ "$installroot" != "default" ]; then
     append_cache_entry BRO_PLUGIN_INSTALL_ROOT PATH $installroot
 fi
 
+if type plugin_addl >/dev/null 2>&1; then
+    plugin_addl
+fi
+
 echo "Build Directory        : $builddir"
 echo "Zeek Source Directory   : $zeekdist"
 

--- a/plugin-support/skeleton/configure
+++ b/plugin-support/skeleton/configure
@@ -119,7 +119,7 @@ if [ -z "$CMakeCommand" ]; then
     elif command -v cmake >/dev/null 2>&1 ; then
         CMakeCommand="cmake"
     else
-        echo "This package requires CMake, please install it first."
+        echo "This plugin requires CMake, please install it first."
         echo "Then you may use this script to configure the CMake build."
         echo "Note: pass --cmake=PATH to use cmake in non-standard locations."
         exit 1;

--- a/plugin-support/skeleton/configure.plugin
+++ b/plugin-support/skeleton/configure.plugin
@@ -24,3 +24,8 @@ plugin_option()
             ;;
     esac
 }
+
+plugin_addl()
+{
+    : # Do nothing
+}

--- a/plugin-support/skeleton/tests/Baseline@%NAME_LOWER.show-plugin@output
+++ b/plugin-support/skeleton/tests/Baseline@%NAME_LOWER.show-plugin@output
@@ -1,0 +1,2 @@
+@PLUGIN_NAMESPACE@::@PLUGIN_NAME@ - <Insert description> (dynamic, version)
+

--- a/plugin-support/skeleton/zkg.meta
+++ b/plugin-support/skeleton/zkg.meta
@@ -1,4 +1,0 @@
-[package]
-script_dir = scripts/@PLUGIN_NAMESPACE@/@PLUGIN_NAME@
-build_command = ./configure && make
-test_command = cd tests && btest


### PR DESCRIPTION
This is an edit pass over `init-plugin` to refocus it purely on plugins. Mainly this just means removing the generation of `zkg.meta`, and adding minor changes that we already have in the plugin feature of the package template. I also expanded `init-plugin` to generate a baseline for the btest it pre-populates, since it seems useful for this test to work out of the box.

We should test the plugin production in CI, for which I'll submit a follow-up PR.