### PR TITLE
Add --disable-cpp-tests to init-plugin's configure template

### DIFF
--- a/plugin-support/skeleton/CMakeLists.txt
+++ b/plugin-support/skeleton/CMakeLists.txt
@@ -5,7 +5,7 @@ project(ZeekPlugin@PLUGIN_NAME@)
 
 include(ZeekPlugin)
 
-zeek_plugin_begin(@PLUGIN_NAMESPACE@ @PLUGIN_NAME@)
+zeek_plugin_begin(@PLUGIN_NAMESPACE@ @PLUGIN_NAME@ ${ZEEK_PLUGIN_BEGIN_OPTS})
 zeek_plugin_cc(src/Plugin.cc)
 zeek_plugin_bif(src/@PLUGIN_NAME_LOWER@.bif)
 zeek_plugin_dist_files(README CHANGES COPYING VERSION)

--- a/plugin-support/skeleton/configure
+++ b/plugin-support/skeleton/configure
@@ -28,6 +28,7 @@ Usage: $0 [OPTIONS]
     --with-caf=DIR             Path to CAF installation root
     --with-bifcl=PATH          Path to bifcl executable
     --enable-debug             Compile in debugging mode
+    --disable-cpp-tests        Don't build C++ unit tests
 EOF
 
 if type plugin_usage >/dev/null 2>&1; then
@@ -52,6 +53,7 @@ append_cache_entry () {
 builddir=build
 zeekdist=""
 installroot="default"
+zeek_plugin_begin_opts=""
 CMakeCacheEntries=""
 
 while [ $# -ne 0 ]; do
@@ -97,7 +99,11 @@ while [ $# -ne 0 ]; do
             ;;
 
         --enable-debug)
-            append_cache_entry BRO_PLUGIN_ENABLE_DEBUG         BOOL   true
+            append_cache_entry BRO_PLUGIN_ENABLE_DEBUG BOOL true
+            ;;
+
+        --disable-cpp-tests)
+            zeek_plugin_begin_opts="DISABLE_CPP_TESTS;$zeek_plugin_begin_opts"
             ;;
 
         *)
@@ -174,6 +180,10 @@ fi
 if [ "$installroot" != "default" ]; then
     mkdir -p $installroot
     append_cache_entry BRO_PLUGIN_INSTALL_ROOT PATH $installroot
+fi
+
+if [ -n "$zeek_plugin_begin_opts" ]; then
+    append_cache_entry ZEEK_PLUGIN_BEGIN_OPTS STRING "$zeek_plugin_begin_opts"
 fi
 
 if type plugin_addl >/dev/null 2>&1; then


### PR DESCRIPTION
This allows suppressing unit-test compilation in a plugin when it's otherwise supported by Zeek. For the much more common case of users just wanting to use unit tests when Zeek supports them, there's no need to change existing plugins.

Part of zeek/zeek#1661.