### PR TITLE
Make some usability updates to git-move-submodules

### DIFF
--- a/devel-tools/git-move-submodules
+++ b/devel-tools/git-move-submodules
@@ -6,9 +6,11 @@
 branch=$1
 
 if [ "$branch" == "" ]; then
-    echo "usage: `basename $0` <branch>"
+    echo "usage: $(basename $0) <branch>"
     exit 1
 fi
+
+paths_to_push=()
 
 function update_module {
     local cwd=$1
@@ -18,16 +20,19 @@ function update_module {
     cd $cwd
 
     # Note we don't use --recursive here, as we want to do a depth-first
-    # search so that we update childrens first.
-    for i in `git submodule foreach -q 'echo $path'`; do
+    # search so that we update childrens first. Update this list of submodules
+    # to include/exclude what should be updated.
+    for i in $(git submodule foreach -q 'echo $path' | grep -v '3rdparty\|highwayhash\|libkqueue\|rapidjson'); do
         # See if repository has a branch of the given name. Otherwise leave it alone.
-        ( cd $i && git show-ref --verify --quiet refs/heads/$branch ) || continue
+        (cd $i && git show-ref --verify --quiet refs/heads/$branch) || continue
 
         modules="$modules $i"
 
-        echo "--- Checking out $branch of `basename $i`"
+        echo "--- Checking out $branch of $(basename $i)"
         cd $i
+        git fetch -q || exit 1
         git checkout -q $branch || exit 1
+        git merge origin/master || exit 1
 
         update_module $cwd/$i
 
@@ -35,18 +40,19 @@ function update_module {
     done
 
     if [ "$modules" != "" ]; then
-        echo "+++ Commiting updates to `basename $cwd`"
-        git commit -m 'Updating submodule(s).
-
- [nomail]' --only $modules
+        if [ -n "$(git status --untracked-files=no --porcelain)" ]; then
+            echo "+++ Commiting updates to $(basename $cwd)"
+            git commit -m 'Updating submodule(s). [nomail]' --only $modules
+            paths_to_push+=($cwd)
+        fi
     fi
 
 }
 
-update_module `pwd`
+update_module $(pwd)
 
-
-
-
-
-
+echo
+echo "Added ${#paths_to_push[@]} commits. Run the following commands to push them:"
+for path in "${paths_to_push[@]}"; do
+    echo "(cd ${path} && git push)"
+done


### PR DESCRIPTION
- Adds some additional filtering to the submodules that get modified, specifically excluding a bunch of 3rd party submodules that usually point at random versioned branches
- Added some output to the script that prints what directories have new commits to push and an easy list of commands to run to push them

Note that I just used this script to update all of the cmake modules across the zeek submodule tree, so it has been tested.