### PR TITLE
Remove the bro-cut symlink

### DIFF
--- a/zeek-cut/CMakeLists.txt
+++ b/zeek-cut/CMakeLists.txt
@@ -5,7 +5,3 @@ set(zeekcut_SRCS
 add_executable(zeek-cut ${zeekcut_SRCS})
 
 install(FILES zeek-cut.1 DESTINATION ${ZEEK_MAN_INSTALL_PATH}/man1)
-
-# Install wrapper script for Bro-to-Zeek renaming.
-include(InstallSymlink)
-InstallSymlink("${CMAKE_INSTALL_PREFIX}/bin/zeek-wrapper" "${CMAKE_INSTALL_PREFIX}/bin/bro-cut")


### PR DESCRIPTION
It was pointing to the now-removed zeek-wrapper, which breaks some binary builds.