### PR TITLE
Remove unsupported `--with-caf` configure option.

### DIFF
--- a/plugin-support/skeleton/configure
+++ b/plugin-support/skeleton/configure
@@ -25,7 +25,6 @@ Usage: $0 [OPTIONS]
     --install-root=DIR         Path where to install plugin into
     --with-binpac=DIR          Path to BinPAC installation root
     --with-broker=DIR          Path to Broker installation root
-    --with-caf=DIR             Path to CAF installation root
     --with-bifcl=PATH          Path to bifcl executable
     --enable-debug             Compile in debugging mode
     --disable-cpp-tests        Don't build C++ unit tests
@@ -87,11 +86,6 @@ while [ $# -ne 0 ]; do
         --with-broker=*)
             append_cache_entry BROKER_ROOT_DIR PATH $optarg
             broker_root=$optarg
-            ;;
-
-        --with-caf=*)
-            append_cache_entry CAF_ROOT_DIR PATH $optarg
-            caf_root=$optarg
             ;;
 
         --with-bifcl=*)
@@ -159,10 +153,6 @@ if [ -z "$zeekdist" ]; then
 
     if [ -z "$broker_root" ]; then
         append_cache_entry BROKER_ROOT_DIR PATH `${zeek_config} --broker_root`
-    fi
-
-    if [ -z "$caf_root" ]; then
-        append_cache_entry CAF_ROOT_DIR PATH `${zeek_config} --caf_root`
     fi
 else
     if [ ! -e "$zeekdist/zeek-path-dev.in" ]; then


### PR DESCRIPTION
`zeek-config` has dropped support for an exposed caf root since at least zeek-5.0.0 so it was impossible to use this option as intended for quite some time. Instead if produced error output during `./configure`.