### PR TITLE
Add missing -m and -M flags to zeek-cut.1 manpage

### DIFF
--- a/zeek-cut/zeek-cut.1
+++ b/zeek-cut/zeek-cut.1
@@ -28,6 +28,12 @@ Include the first format header block in the output.
 \fB\-C\fR
 Include all format header blocks in the output.
 .TP
+\fB-m\fR
+Include the first format header block in the output in minimal view.
+.TP
+\fB-M\fR
+Include all format header blocks in the output in minimal view.
+.TP
 \fB\-d\fR
 Convert time values into human\-readable format.
 .HP


### PR DESCRIPTION
I took a quick look at generating that page via `help2man` but the current one seems much nicer — perhaps it got started off with `help2man` and then spruced up. So I just put in Bill's suggestion and made him co-author. :-)

Resolves #39.