### PR TITLE
Fix GNU grep 3.8 warnings

### DIFF
--- a/ci/centos-stream-8/Dockerfile
+++ b/ci/centos-stream-8/Dockerfile
@@ -6,6 +6,7 @@ RUN dnf config-manager --set-enabled powertools
 RUN dnf -y update && dnf -y install \
     git \
     cmake3 \
+    diffutils \
     gcc-c++ \
     libpcap-devel \
     make \

--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf -y install \
 
 RUN dnf -y update && dnf -y install \
     cmake3 \
+    diffutils \
     gcc-c++ \
     git \
     libpcap-devel \

--- a/devel-tools/make-release
+++ b/devel-tools/make-release
@@ -30,7 +30,7 @@ function release()
             tgz="`pwd`/$tgz"
         fi
 
-        version=`git tag --contains HEAD | egrep '^(release|beta)$'`
+        version=`git tag --contains HEAD | grep -E '^(release|beta)$'`
 
         if [ "$version" == "" ]; then
             version="git"

--- a/devel-tools/update-changes
+++ b/devel-tools/update-changes
@@ -246,7 +246,7 @@ function add_to_changes_entry
         return 1;
     fi
 
-   if echo $msg | grep -q '^\(.*:\ *\)\{0,1\}Merge remote-tracking branch'; then # allow GH-XXX prefix
+   if echo $msg | grep -q '^\(.*: *\)\{0,1\}Merge remote-tracking branch'; then # allow GH-XXX prefix
        # Ignore merge commits.
        return 1;
    fi

--- a/devel-tools/update-changes
+++ b/devel-tools/update-changes
@@ -324,7 +324,7 @@ function init_changes
 
 function get_last_rev
 {
-    version=`cat $file_changes | egrep '^[0-9a-zA-Z.-]+  *\|' | head -1 | awk '{print $1}'`
+    version=`cat $file_changes | grep -E '^[0-9a-zA-Z.-]+  *\|' | head -1 | awk '{print $1}'`
 
     if echo $version | grep -q -- '-'; then
         # version is now e.g. 1.0.4-14 -- find the revision with that number.
@@ -396,7 +396,7 @@ function get_release_version {
     # If $1 is provided, return that. Otherwise look for most recent release
     # version in CHANGES and increase its point version.
     test -n "$1" && echo "$1" && return
-    old=$(cat $file_changes | egrep '^[0-9]+\.[0-9]+\.[0-9]+(-(dev\.)?[0-9]+)? ' | cut -d ' ' -f 1 | head -1)
+    old=$(cat $file_changes | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-(dev\.)?[0-9]+)? ' | cut -d ' ' -f 1 | head -1)
     test -z "${old}" && echo "" && return
     point=$(echo ${old} | cut -d - -f 1 | cut -d . -f 3)
     point=$((${point} + 1))
@@ -476,7 +476,7 @@ else
 fi
 
 if [ "$release" != "" ]; then
-    if ! echo $release | egrep -q '^v[0-9]+\.[0-9]+'; then
+    if ! echo $release | grep -E -q '^v[0-9]+\.[0-9]+'; then
         echo "Release tag must be of the form vX.Y[.Z]"
         exit 1
     fi
@@ -485,7 +485,7 @@ if [ "$release" != "" ]; then
 fi
 
 if [ "$beta" != "" ]; then
-    if ! echo $beta | egrep -q '^v[0-9]+\.[0-9]+(\.[0-9]+)?-(beta|rc)'; then
+    if ! echo $beta | grep -E -q '^v[0-9]+\.[0-9]+(\.[0-9]+)?-(beta|rc)'; then
         echo "Release tag must be of the form vX.Y[.Z]-(beta|rc)*"
         exit 1
     fi


### PR DESCRIPTION
I noticed that `update-changes` now included some of those recent warnings on my system:
```
$ update-changes
Reading .update-changes.cfg ...
egrep: warning: egrep is obsolescent; using grep -E
New version is 1.0-13.
Listing revisions commited since 1.0-10 (0c3cafb2ed638f88a446732fa03d90af9bcf796c) ...

grep: warning: stray \ before white space
 8716329 | Christian Kreibich | Merge branch 'topic/christian/ci-pypi'
grep: warning: stray \ before white space
 c55335a | Christian Kreibich | Make this a test environment
grep: warning: stray \ before white space
 4013b78 | Christian Kreibich | CI: automatically push to PyPI when pushing a git tag

Update to CHANGES will be amended to last commit.

Type Enter to edit new CHANGES, or CTRL-C to abort without any modifications.

Updated CHANGES.
Updated 1.0-11 to 1.0-13.
[master 3532e9c] Merge branch 'topic/christian/ci-pypi'
 Date: Fri Jun 30 15:13:37 2023 -0700
Updates committed.
```