### PR TITLE
rst: Handle setuid() error

### DIFF
--- a/rst/rst.c
+++ b/rst/rst.c
@@ -374,7 +374,8 @@ int main(int argc, char **argv)
 	if ( s < 0 )
 		pgripe("couldn't create raw socket");
 
-	setuid(getuid());
+	if ( setuid(getuid()) )
+		pgripe("couldn't lower privileges");
 
 	if ( setsockopt(s, 0, IP_HDRINCL, (char *) &on, sizeof(on)) < 0 )
 		pgripe("can't turn on IP_HDRINCL");


### PR DESCRIPTION
Mostly to squelch the warning here, not sure anyone is using this...

    zeek-aux/rst/rst.c:377:9: warning: ignoring return value of ‘setuid’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
      377 |         setuid(getuid());