### PR TITLE
Always install zeek-archiver, not optionally like adtrace and rst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,6 @@ if (NOT (BINARY_PACKAGING_MODE OR
     add_dependencies(install-aux ${AUX_TARGETS})
 endif ()
 
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/zeek-cut/zeek-cut DESTINATION bin)
-
 ########################################################################
 ## Build Summary
 

--- a/zeek-archiver/CMakeLists.txt
+++ b/zeek-archiver/CMakeLists.txt
@@ -3,4 +3,4 @@ add_executable(zeek-archiver zeek-archiver.cc)
 set_target_properties(zeek-archiver PROPERTIES COMPILE_FLAGS
     "-std=c++17 -Wall -Wno-unused -Werror=vla")
 
-AddAuxInstallTarget(zeek-archiver)
+install(TARGETS zeek-archiver)

--- a/zeek-cut/CMakeLists.txt
+++ b/zeek-cut/CMakeLists.txt
@@ -4,4 +4,5 @@ set(zeekcut_SRCS
 
 add_executable(zeek-cut ${zeekcut_SRCS})
 
+install(TARGETS zeek-cut)
 install(FILES zeek-cut.1 DESTINATION ${ZEEK_MAN_INSTALL_PATH}/man1)


### PR DESCRIPTION
I overlooked that zeek-archiver is not like rst or adtrace — we currently always install it, so let's keep doing that.