### PR TITLE
Ignore merges of local branches in `update-changes`

### DIFF
--- a/devel-tools/update-changes
+++ b/devel-tools/update-changes
@@ -246,8 +246,8 @@ function add_to_changes_entry
         return 1;
     fi
 
-   if echo $msg | grep -q '^\(.*: *\)\{0,1\}Merge remote-tracking branch'; then # allow GH-XXX prefix
-       # Ignore merge commits.
+    if [[ $(git show --no-patch --format='%P' "$rev" | wc -w) -gt 1 ]]; then
+       # Ignore merge commits, i.e., commits with more than one parent.
        return 1;
    fi
 


### PR DESCRIPTION
We previously would ignore merges of remote branches when creating CHANGELOG entries, but let merges of local branches through. This was due to `update-changes` identifying merges through their Git-generated commit message which assumes that the message was not edited.

With this patch we add proper detection of merge commits in that any commit with more than a single parent is handled as a merge and excluded from the generated `CHANGELOG`.