### PR TITLE
CI: fix installation of external packages on macos

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,17 +82,10 @@ ubuntu20_task:
     dockerfile: ci/ubuntu-20.04/Dockerfile
   << : *CI_TEMPLATE
 
-# Apple doesn't publish official long-term support timelines.
-# We aim to support both the current and previous macOS release.
+# Cirrus currently only supports running on Sonoma.
 macos_sonoma_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-base:latest
-  prepare_script: ./ci/macos/prepare.sh
-  << : *CI_TEMPLATE
-
-macos_ventura_task:
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
 

--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -9,7 +9,12 @@ brew update
 brew upgrade cmake
 brew install openssl@1.1
 
-sudo python3 -m pip install btest
+# Install btest in a venv since under macos pip refuses to install into the
+# global prefix since it is explicitly "externally managed".
+python3 -mvenv ./btest.venv
+# shellcheck disable=SC1091
+. ./btest.venv/bin/activate
+pip install btest
 
 # Brew doesn't create the /opt/homebrew/opt/openssl symlink if you install
 # openssl@1.1, only with 3.0. Create the symlink if it doesn't exist.

--- a/ci/run-ci
+++ b/ci/run-ci
@@ -48,6 +48,11 @@ function run_tests {
 
 test -n "${cmd}" || usage
 
+if [ -e btest.venv ]; then
+    # shellcheck disable=SC1091
+    . btest.venv/bin/activate
+fi
+
 case "${cmd}" in
     build)
         run_build $@


### PR DESCRIPTION
Under macos the Python prefix is marked "externally managed" so `pip`
refuses to install additional packages into it. Switch the macos CI jobs
to use a venv instead.