### PR TITLE
zeek-archiver: Respect umask setting

### DIFF
--- a/testing/zeek-archiver/umask.test
+++ b/testing/zeek-archiver/umask.test
@@ -1,0 +1,36 @@
+# @TEST-DOC: Check file permissions with different umask settings.
+# @TEST-EXEC: bash %INPUT
+
+. "$SCRIPTS/zeek-archiver-common.sh"
+
+umask 0002
+
+log_in=test__2020-07-16-09-43-10__2020-07-16-09-43-10__.log
+log_out=test.09:43:10-09:43:10.log
+
+echo hello > "$(queue_dir)/${log_in}"
+zeek-archiver -1 -v "$(queue_dir)" "$(archive_dir)"
+
+dir_perms=$(ls -ld $(archive_date_dir) | cut -d ' ' -f 1)
+file_perms=$(ls -l $(archive_date_dir)/${log_out}.gz | cut -d ' ' -f 1)
+
+test "${dir_perms}" == "drwxrwxr-x"  || exit 1
+test "${file_perms}" == "-rw-rw-r--" || exit 1
+
+# @TEST-START-NEXT
+
+. "$SCRIPTS/zeek-archiver-common.sh"
+
+umask 0077
+
+log_in=test__2020-07-16-09-43-10__2020-07-16-09-43-10__.log
+log_out=test.09:43:10-09:43:10.log
+
+echo hello > "$(queue_dir)/${log_in}"
+zeek-archiver -1 -v "$(queue_dir)" "$(archive_dir)"
+
+dir_perms=$(ls -ld $(archive_date_dir) | cut -d ' ' -f 1)
+file_perms=$(ls -l $(archive_date_dir)/${log_out}.gz | cut -d ' ' -f 1)
+
+test "${dir_perms}" == "drwx------" || exit 1
+test "${file_perms}" == "-rw-------"  || exit 1

--- a/zeek-archiver/zeek-archiver.cc
+++ b/zeek-archiver/zeek-archiver.cc
@@ -397,7 +397,7 @@ static void parse_options(int argc, char** argv)
 
 static bool make_dir(const char* dir)
 	{
-	if ( mkdir(dir, 0700) == 0 )
+	if ( mkdir(dir, 0775) == 0 )
 		return true;
 
 	auto mkdir_errno = errno;
@@ -540,7 +540,7 @@ static int run_compress_cmd(const char* src_file, const char* dst_file)
 		if ( src_fd != STDIN_FILENO )
 			close(src_fd);
 
-		int dst_fd = open(dst_file, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+		int dst_fd = open(dst_file, O_CREAT | O_TRUNC | O_WRONLY, 0664);
 
 		if ( dst_fd < 0 )
 			{


### PR DESCRIPTION
Rather than hard-coding 0700 and 0644, use 0775 and 0664 and assume and rely on open() and mkdir() to pick up the environment's umask value.

This may theoretically break someone relying on the strict permissions, but I'd argue it's not worth a configuration option. And pointing them at umask may be pragmatic enough.

Closes #57.