### PR TITLE
Make zeek-archiver tests robust to filesystems with extended attributes

### DIFF
--- a/testing/zeek-archiver/umask.test
+++ b/testing/zeek-archiver/umask.test
@@ -11,8 +11,8 @@ log_out=test.09:43:10-09:43:10.log
 echo hello > "$(queue_dir)/${log_in}"
 zeek-archiver -1 -v "$(queue_dir)" "$(archive_dir)"
 
-dir_perms=$(ls -ld $(archive_date_dir) | cut -d ' ' -f 1)
-file_perms=$(ls -l $(archive_date_dir)/${log_out}.gz | cut -d ' ' -f 1)
+dir_perms=$(ls -ld $(archive_date_dir) | cut -c -10)
+file_perms=$(ls -l $(archive_date_dir)/${log_out}.gz | cut -c -10)
 
 test "${dir_perms}" == "drwxrwxr-x"  || exit 1
 test "${file_perms}" == "-rw-rw-r--" || exit 1
@@ -29,8 +29,8 @@ log_out=test.09:43:10-09:43:10.log
 echo hello > "$(queue_dir)/${log_in}"
 zeek-archiver -1 -v "$(queue_dir)" "$(archive_dir)"
 
-dir_perms=$(ls -ld $(archive_date_dir) | cut -d ' ' -f 1)
-file_perms=$(ls -l $(archive_date_dir)/${log_out}.gz | cut -d ' ' -f 1)
+dir_perms=$(ls -ld $(archive_date_dir) | cut -c -10)
+file_perms=$(ls -l $(archive_date_dir)/${log_out}.gz | cut -c -10)
 
 test "${dir_perms}" == "drwx------" || exit 1
 test "${file_perms}" == "-rw-------"  || exit 1


### PR DESCRIPTION
On such systems the permission string has an extra character, as in "drwxr-xr-x.", which fails the string comparisons in the umask tests. Cut off the result after 10 characters to ignore that column.