### PR TITLE
Require C++20 for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(ZeekAux C CXX)
 include(cmake/CommonCMakeConfig.cmake)
+include(cmake/RequireCXXStd.cmake)
 
 # ##############################################################################
 # Dependency Configuration

--- a/zeek-archiver/CMakeLists.txt
+++ b/zeek-archiver/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(../cmake/RequireCXXStd.cmake)
+
 add_executable(zeek-archiver zeek-archiver.cc)
 
 set_target_properties(zeek-archiver PROPERTIES COMPILE_FLAGS


### PR DESCRIPTION
This bumps the cmake submodule to a version that requires C++20 and makes a few other minor changes to use that. It also bumps the required version of CMake up to 3.15 to match all of the other Zeek repos.