### PR TITLE
Remove BRO_DIST from plugin skeleton configure script

### DIFF
--- a/plugin-support/skeleton/configure
+++ b/plugin-support/skeleton/configure
@@ -160,9 +160,6 @@ else
         exit 1
     fi
 
-    # BRO_DIST is the canonical/historical name used by plugin CMake scripts
-    # ZEEK_DIST doesn't serve a function at the moment, but set/provided anyway
-    append_cache_entry BRO_DIST PATH $zeekdist
     append_cache_entry ZEEK_DIST PATH $zeekdist
     append_cache_entry CMAKE_MODULE_PATH PATH $zeekdist/cmake
 fi


### PR DESCRIPTION
The `BRO_DIST` variable was removed from our CMake setup a long time ago, and just causes new plugins to emit a useless warning. Remove it and the comment related to it. This also removes the comment related to `ZEEK_DIST`, which is actually used in `ZeekPlugin.cmake`.